### PR TITLE
test: lint `.proto` files with `buf lint`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "format:prettier": "prettier --write .",
     "format": "npm-run-all --parallel format:*",
     "lint:buf-format": "buf format --diff --exit-code ./proto",
+    "lint:buf-lint": "buf lint ./proto",
     "lint:prettier": "prettier --check .",
     "lint": "npm-run-all --parallel lint:*",
     "prepack": "npm run build",


### PR DESCRIPTION
[`buf lint`](https://buf.build/docs/lint/overview/) might help us catch protobuf issues.

It seems we're already doing this in CI (see `buf-ci.yaml`) but I think it'd be useful to be able to run this locally.