### PR TITLE
chore: don't run buf CI on push

### DIFF
--- a/.github/workflows/buf-ci.yaml
+++ b/.github/workflows/buf-ci.yaml
@@ -1,6 +1,5 @@
 name: Buf CI
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
   delete:


### PR DESCRIPTION
We don't need this to run on push, since this is only needed for pushing to the buf repository.