### PR TITLE
fix: add missing 'type' field with value 'object' on schema

### DIFF
--- a/json/geometry.json
+++ b/json/geometry.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://comapeo.app/schemas/shared/geometry.json",
   "title": "Geometry",
-  "type": "array",
+  "type": "object",
   "description": "A subset of the GeoJSON geometry object.",
   "definitions": {
     "position": {

--- a/json/geometry.json
+++ b/json/geometry.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://comapeo.app/schemas/shared/geometry.json",
   "title": "Geometry",
-  "type": "object",
+  "type": "array",
   "description": "A subset of the GeoJSON geometry object.",
   "definitions": {
     "position": {

--- a/json/geometry.json
+++ b/json/geometry.json
@@ -2,6 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "http://comapeo.app/schemas/shared/geometry.json",
   "title": "Geometry",
+  "type": "object",
   "description": "A subset of the GeoJSON geometry object.",
   "definitions": {
     "position": {


### PR DESCRIPTION
re-generating drizzle:client on `comapeo-core` when integrating `remoteDetectionAlert` schema (which includes @comapeo/geometry) yields an error on [here](https://github.com/digidem/comapeo-core/blob/dfaceb29186c695b04f037ffa31321c7588d1270/src/schema/schema-to-drizzle.js#L30). This is because we're missing a `type` field on the geometry schema which should be of value `object`. 
This PR fixes that