### PR TITLE
feat: named exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./schema": "./json/geometry.json"
+  },
   "scripts": {
     "build": "npm-run-all build:clean build:proto build:json build:ts build:copy",
     "build:clean": "rimraf dist intermediate generated",


### PR DESCRIPTION
To allow a more straightaway import of the JSONSchema, this PR adds a named export of the schema to the package.
I also added a default export (`".": "./dist/index.js"`), but I'm also wondering if we should add other exports (and also types) or if this is sufficient for not breaking the package import in other contexts